### PR TITLE
Migrate to organization-wide reusable Docker workflow

### DIFF
--- a/.github/workflows.backup.20250725_122329/build.yml
+++ b/.github/workflows.backup.20250725_122329/build.yml
@@ -1,0 +1,68 @@
+name: Docker Builds
+
+# Controls when the workflow will run
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Get the repositery's code
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Retrieve version
+        run: |
+          echo -n "$(git describe --tags)" > .version
+        id: version
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/aloma-io/connector-1password
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=semver,pattern=v{{version}}
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./
+          file: ./Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+      - name: Update notification
+        env:
+          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+        run: |
+          export REFNAME=$(echo $GITHUB_REF | cut -d '/' -f 3)
+          VERSION="$REFNAME"
+
+          update="{\"build\": {\"type\": \"connector\", \"connectorId\": \"d7gmtzdcmugdm403ihke4x87bfgpf6h6\", \"image\": \"ghcr.io/aloma-io/connector-1password:${VERSION}\", \"version\": \"${VERSION}\"}}"
+
+          curl -X POST -H 'Content-type: application/json' --data-binary "$update" "$WEBHOOK_URL"
+          
+      

--- a/.github/workflows.backup/build.yml
+++ b/.github/workflows.backup/build.yml
@@ -12,7 +12,7 @@ jobs:
     uses: aloma-io/.github/.github/workflows/docker-build-push.yml@main
     with:
       image_name: 'connector-1password'
-      dockerfile: 'Dockerfile'
+      dockerfile: 'Containerfile'
       context: '.'
       tags: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,4 +15,7 @@ jobs:
       dockerfile: 'Containerfile'
       context: '.'
       tags: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
-    secrets: inherit
+    secrets:
+      AZURE_USER: ${{ secrets.REGISTRY_USER }}
+      AZURE_PASS: ${{ secrets.REGISTRY_PASS }}
+      GOOGLE_CLOUD_KEY: ${{ secrets.GOOGLE_CLOUD_KEY }}

--- a/.github/workflows/build.yml.backup-20250725_163923
+++ b/.github/workflows/build.yml.backup-20250725_163923
@@ -12,7 +12,7 @@ jobs:
     uses: aloma-io/.github/.github/workflows/docker-build-push.yml@main
     with:
       image_name: 'connector-1password'
-      dockerfile: 'Containerfile'
+      dockerfile: 'Dockerfile'
       context: '.'
       tags: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
     secrets: inherit

--- a/.github/workflows/build.yml.backup-20250725_164025
+++ b/.github/workflows/build.yml.backup-20250725_164025
@@ -12,7 +12,7 @@ jobs:
     uses: aloma-io/.github/.github/workflows/docker-build-push.yml@main
     with:
       image_name: 'connector-1password'
-      dockerfile: 'Containerfile'
+      dockerfile: 'Dockerfile'
       context: '.'
       tags: ${{ github.ref_type == 'tag' && github.ref_name || 'latest' }}
     secrets: inherit

--- a/Containerfile
+++ b/Containerfile
@@ -10,9 +10,10 @@ COPY ./tsconfig.json ./
 COPY ./entrypoint.sh ./
 COPY ./src ./src
 COPY ./logo.png ./logo.png
-COPY ./.version ./.version
 
-RUN set -e; npm --no-git-tag-version --allow-same-version version $(cat .version); 
+# COPY ./.version ./.version
+# RUN set -e; npm --no-git-tag-version --allow-same-version version $(cat .version);
+
 RUN set -e; addgroup -g 1111 connector; adduser -S -u 1111 -G connector connector
 
 RUN set -e; apk add --no-cache git python3 make g++; yarn config set --home enableTelemetry 0; chmod 755 /connector/entrypoint.sh; cd /connector/; yarn install --frozen-lockfile; yarn run build

--- a/MIGRATION_TO_REUSABLE_WORKFLOW.md
+++ b/MIGRATION_TO_REUSABLE_WORKFLOW.md
@@ -1,0 +1,27 @@
+# Migration to Reusable Workflow
+
+This repository has been migrated to use the organization-wide reusable Docker workflow.
+
+## Changes Made
+
+- Replaced local workflow with call to `aloma-io/.github/.github/workflows/docker-build-push.yml@main`
+- Configuration: 
+  - Image name: `connector-1password`
+  - Dockerfile: `Dockerfile`
+  - Context: `.`
+- Backed up previous workflows to `.github/workflows.backup/`
+
+## Benefits
+
+- Centralized maintenance
+- Consistent behavior across repositories  
+- Automatic updates when the central workflow is improved
+- Simplified configuration
+- Docker build caching support
+- Parallel pushes to Azure and Google registries
+
+## Documentation
+
+See: https://github.com/aloma-io/.github/blob/main/REUSABLE_WORKFLOWS.md
+
+Migration performed on: Fri Jul 25 13:48:18 -03 2025

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+# Trigger rebuild


### PR DESCRIPTION
This PR migrates the repository to use the centralized reusable Docker workflow from aloma-io/.github. Migration automated on Fri Jul 25 13:48:20 -03 2025